### PR TITLE
Do not explicitly exclude the '_id' field when returning documents as_py...

### DIFF
--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -1459,7 +1459,7 @@ class QuerySet(object):
         # used. If not, handle all fields.
         if not getattr(self, '__as_pymongo_fields', None):
             self.__as_pymongo_fields = []
-            for field in self._loaded_fields.fields - set(['_cls', '_id']):
+            for field in self._loaded_fields.fields - set(['_cls']):
                 self.__as_pymongo_fields.append(field)
                 while '.' in field:
                     field, _ = field.rsplit('.', 1)


### PR DESCRIPTION
The current QuerySet implementation will exclude the _id field from the set of return fields when QuerySet.as_pymongo() is called. Here's an example:

class Sample(Document):
   foo = StringField()
   zot = StringField()

Sample(foo="bar", zot="baz").save()
raw_doc = list(Sample.objects().only('id', 'foo').as_pymongo())[0]
# raw_doc would be returned as: {'foo': 'bar'}, instead of {''_id': ObjectId('...'), foo': 'bar'}
