### PR TITLE
dedupe the $in operator

### DIFF
--- a/mongoengine/queryset/visitor.py
+++ b/mongoengine/queryset/visitor.py
@@ -1,8 +1,6 @@
 import copy
 
 from mongoengine.errors import InvalidQueryError
-from mongoengine.python_support import product, reduce
-
 from mongoengine.queryset import transform
 
 __all__ = ('Q',)

--- a/tests/queryset/transform.py
+++ b/tests/queryset/transform.py
@@ -98,14 +98,19 @@ class TransformTest(unittest.TestCase):
 
         B(a=a1).save()
 
-        # Works
         q1 = B.objects.filter(a__in=[a1, a2], a=a1)._query
 
-        # Doesn't work
         q2 = B.objects.filter(a__in=[a1, a2])
         q2 = q2.filter(a=a1)._query
 
         self.assertEqual(q1, q2)
+
+    def test_in_operator_dedupe(self):
+        class A(Document):
+            text = StringField()
+
+        q = A.objects.filter(text__in=['a', 'b', 'a'])._query
+        self.assertEqual(q, { 'text': { '$in': ['a', 'b'] } })
 
     def test_raw_query_and_Q_objects(self):
         """


### PR DESCRIPTION
Just a suggestion. It uses a set and therefore doesn't work with unhashable types (e.g. dicts). @thomasst what do you think about it?