### PR TITLE
Get without ordering

### DIFF
--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -246,7 +246,7 @@ class QuerySet(object):
         .. versionadded:: 0.3
         """
         queryset = self.__call__(*q_objs, **query)
-        queryset = queryset.limit(2)
+        queryset = queryset.order_by().limit(2)
         try:
             result = queryset.next()
         except StopIteration:


### PR DESCRIPTION
Fixes the issue highlighted below:

```
In [20]: with our_query_counter(verbose=True) as q:
    Email.objects.get(pk='some_pk')
    print q
   ....:
--------------------------------------------------------------------------------
closeio.activity {u'$orderby': {u'date_created': -1}, u'$query': {u'_id': u'some_pk', u'_cls': u'Activity.Email'}}

--------------------------------------------------------------------------------
1

In [21]: with our_query_counter(verbose=True) as q:
    Email.objects.order_by().get(pk='some_pk')
    print q
   ....:
--------------------------------------------------------------------------------
closeio.activity {u'_id': u'some_pk', u'_cls': u'Activity.Email'}

--------------------------------------------------------------------------------
1
```
