### PR TITLE
Don't create indexes by default

### DIFF
--- a/mongoengine/base/common.py
+++ b/mongoengine/base/common.py
@@ -2,7 +2,10 @@ from mongoengine.errors import NotRegistered
 
 __all__ = ('ALLOW_INHERITANCE', 'AUTO_CREATE_INDEX', 'get_document', '_document_registry')
 
+# don't allow inheritance by default
 ALLOW_INHERITANCE = False
+
+# don't automatically create indexes
 AUTO_CREATE_INDEX = False
 
 _document_registry = {}

--- a/mongoengine/base/common.py
+++ b/mongoengine/base/common.py
@@ -1,8 +1,9 @@
 from mongoengine.errors import NotRegistered
 
-__all__ = ('ALLOW_INHERITANCE', 'get_document', '_document_registry')
+__all__ = ('ALLOW_INHERITANCE', 'AUTO_CREATE_INDEX', 'get_document', '_document_registry')
 
 ALLOW_INHERITANCE = False
+AUTO_CREATE_INDEX = False
 
 _document_registry = {}
 

--- a/mongoengine/base/metaclasses.py
+++ b/mongoengine/base/metaclasses.py
@@ -245,8 +245,6 @@ class TopLevelDocumentMetaclass(DocumentMetaclass):
                 'ordering': [],  # default ordering applied at runtime
                 'indexes': [],  # indexes to be ensured at runtime
                 'id_field': None,
-                'index_background': False,
-                'index_drop_dups': False,
                 'index_opts': None,
                 'delete_rules': None,
                 'allow_inheritance': None,

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -606,7 +606,7 @@ class Document(BaseDocument):
             indexes.append(_id_spec)
 
         if (
-            cls._meta['index_cls'] and
+            cls._meta.get('index_cls', True) and
             cls._meta.get('allow_inheritance', ALLOW_INHERITANCE)
         ):
             cls_exists = False
@@ -617,29 +617,6 @@ class Document(BaseDocument):
                 indexes.append({ 'key': [('_cls', 1)] })
 
         return indexes
-
-    @classmethod
-    def compare_indexes(cls):
-        """ Compares the indexes defined in MongoEngine with the ones existing
-        in the database. Returns any missing/extra indexes.
-        """
-
-        required = cls.list_indexes()
-        existing = [info['key'] for info in cls._get_collection().index_information().values()]
-        missing = [index for index in required if index not in existing]
-        extra = [index for index in existing if index not in required]
-
-        # if { _cls: 1 } is missing, make sure it's *really* necessary
-        if [(u'_cls', 1)] in missing:
-            cls_obsolete = False
-            for index in existing:
-                if includes_cls(index) and index not in extra:
-                    cls_obsolete = True
-                    break
-            if cls_obsolete:
-                missing.remove([(u'_cls', 1)])
-
-        return {'missing': missing, 'extra': extra}
 
 
 class DynamicDocument(Document):

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -5,7 +5,8 @@ from bson.dbref import DBRef
 from mongoengine import signals
 from mongoengine.common import _import_class
 from mongoengine.base import (DocumentMetaclass, TopLevelDocumentMetaclass,
-                              BaseDocument, ALLOW_INHERITANCE, get_document)
+                              BaseDocument, get_document, ALLOW_INHERITANCE,
+                              AUTO_CREATE_INDEX)
 from mongoengine.base.datastructures import WeakInstanceMixin
 from mongoengine.queryset import OperationError, NotUniqueError, QuerySet, DoesNotExist
 from mongoengine.connection import get_db, DEFAULT_CONNECTION_NAME
@@ -167,7 +168,7 @@ class Document(BaseDocument):
                     )
             else:
                 cls._collection = db[collection_name]
-            if cls._meta.get('auto_create_index', True):
+            if cls._meta.get('auto_create_index', AUTO_CREATE_INDEX):
                 cls.ensure_indexes()
         return cls._collection
 

--- a/tests/document/class_methods.py
+++ b/tests/document/class_methods.py
@@ -85,110 +85,6 @@ class ClassMethodsTest(unittest.TestCase):
         self.assertEqual(self.Person._meta['delete_rules'],
                          {(Job, 'employee'): NULLIFY})
 
-    def test_compare_indexes(self):
-        """ Ensure that the indexes are properly created and that
-        compare_indexes identifies the missing/extra indexes
-        """
-
-        class BlogPost(Document):
-            author = StringField()
-            title = StringField()
-            description = StringField()
-            tags = StringField()
-
-            meta = {
-                'indexes': [('author', 'title')]
-            }
-
-        BlogPost.drop_collection()
-
-        BlogPost.ensure_indexes()
-        self.assertEqual(BlogPost.compare_indexes(), { 'missing': [], 'extra': [] })
-
-        BlogPost.ensure_index(['author', 'description'])
-        self.assertEqual(BlogPost.compare_indexes(), { 'missing': [], 'extra': [[('author', 1), ('description', 1)]] })
-
-        BlogPost._get_collection().drop_index('author_1_description_1')
-        self.assertEqual(BlogPost.compare_indexes(), { 'missing': [], 'extra': [] })
-
-        BlogPost._get_collection().drop_index('author_1_title_1')
-        self.assertEqual(BlogPost.compare_indexes(), { 'missing': [[('author', 1), ('title', 1)]], 'extra': [] })
-
-    def test_compare_indexes_inheritance(self):
-        """ Ensure that the indexes are properly created and that
-        compare_indexes identifies the missing/extra indexes for subclassed
-        documents (_cls included)
-        """
-
-        class BlogPost(Document):
-            author = StringField()
-            title = StringField()
-            description = StringField()
-
-            meta = {
-                'allow_inheritance': True
-            }
-
-        class BlogPostWithTags(BlogPost):
-            tags = StringField()
-            tag_list = ListField(StringField())
-
-            meta = {
-                'indexes': [('author', 'tags')]
-            }
-
-        BlogPost.drop_collection()
-
-        BlogPost.ensure_indexes()
-        BlogPostWithTags.ensure_indexes()
-        self.assertEqual(BlogPost.compare_indexes(), { 'missing': [], 'extra': [] })
-
-        BlogPostWithTags.ensure_index(['author', 'tag_list'])
-        self.assertEqual(BlogPost.compare_indexes(), { 'missing': [], 'extra': [[('_cls', 1), ('author', 1), ('tag_list', 1)]] })
-
-        BlogPostWithTags._get_collection().drop_index('_cls_1_author_1_tag_list_1')
-        self.assertEqual(BlogPost.compare_indexes(), { 'missing': [], 'extra': [] })
-
-        BlogPostWithTags._get_collection().drop_index('_cls_1_author_1_tags_1')
-        self.assertEqual(BlogPost.compare_indexes(), { 'missing': [[('_cls', 1), ('author', 1), ('tags', 1)]], 'extra': [] })
-
-    def test_compare_indexes_multiple_subclasses(self):
-        """ Ensure that compare_indexes behaves correctly if called from a
-        class, which base class has multiple subclasses
-        """
-
-        class BlogPost(Document):
-            author = StringField()
-            title = StringField()
-            description = StringField()
-
-            meta = {
-                'allow_inheritance': True
-            }
-
-        class BlogPostWithTags(BlogPost):
-            tags = StringField()
-            tag_list = ListField(StringField())
-
-            meta = {
-                'indexes': [('author', 'tags')]
-            }
-
-        class BlogPostWithCustomField(BlogPost):
-            custom = DictField()
-
-            meta = {
-                'indexes': [('author', 'custom')]
-            }
-
-        BlogPost.ensure_indexes()
-        BlogPostWithTags.ensure_indexes()
-        BlogPostWithCustomField.ensure_indexes()
-
-        self.assertEqual(BlogPost.compare_indexes(), { 'missing': [], 'extra': [] })
-        self.assertEqual(BlogPostWithTags.compare_indexes(), { 'missing': [], 'extra': [] })
-        self.assertEqual(BlogPostWithCustomField.compare_indexes(), { 'missing': [], 'extra': [] })
-
     def test_list_indexes_inheritance(self):
         """ ensure that all of the indexes are listed regardless of the super-
         or sub-class that we call it from
@@ -227,10 +123,12 @@ class ClassMethodsTest(unittest.TestCase):
                          BlogPostWithTags.list_indexes())
         self.assertEqual(BlogPost.list_indexes(),
                          BlogPostWithTagsAndExtraText.list_indexes())
-        self.assertEqual(BlogPost.list_indexes(),
-                         [[('_cls', 1), ('author', 1), ('tags', 1)],
-                         [('_cls', 1), ('author', 1), ('tags', 1), ('extra_text', 1)],
-                         [(u'_id', 1)], [('_cls', 1)]])
+        self.assertEqual(BlogPost.list_indexes(), [
+            { 'key': [('_cls', 1), ('author', 1), ('tags', 1)] },
+            { 'key': [('_cls', 1), ('author', 1), ('tags', 1), ('extra_text', 1)] },
+            { 'key': [(u'_id', 1)] },
+            { 'key': [('_cls', 1)] },
+        ])
 
     def test_register_delete_rule_inherited(self):
 

--- a/tests/document/indexes.py
+++ b/tests/document/indexes.py
@@ -764,20 +764,15 @@ class IndexesTest(unittest.TestCase):
         self.assertEqual(index_info, {
             'txt_1': {
                 'key': [('txt', 1)],
-                'dropDups': False,
-                'background': False
             },
             '_id_': {
                 'key': [('_id', 1)],
             },
             'txt2_1': {
                 'key': [('txt2', 1)],
-                'dropDups': False,
-                'background': False
             },
             '_cls_1': {
                 'key': [('_cls', 1)],
-                'background': False,
             }
         })
 

--- a/tests/document/indexes.py
+++ b/tests/document/indexes.py
@@ -197,8 +197,7 @@ class IndexesTest(unittest.TestCase):
 
         Person.drop_collection()
 
-        # Indexes are lazy so use list() to perform query
-        list(Person.objects)
+        Person.ensure_indexes()
         info = Person.objects._collection.index_information()
         info = [value['key'] for key, value in info.iteritems()]
         self.assertTrue([('rank.title', 1)] in info)
@@ -266,6 +265,7 @@ class IndexesTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+        BlogPost.ensure_indexes()
         info = BlogPost.objects._collection.index_information()
         # _id, '-date'
         self.assertEqual(len(info), 2)
@@ -298,6 +298,8 @@ class IndexesTest(unittest.TestCase):
                 'indexes': ['name'],
             }
         Person.drop_collection()
+
+        Person.ensure_indexes()
 
         Person(name="test", user_guid='123').save()
 
@@ -353,6 +355,7 @@ class IndexesTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+        BlogPost.ensure_indexes()
         info = BlogPost.objects._collection.index_information()
         self.assertEqual(sorted(info.keys()), ['_id_', 'date.yr_-1'])
         BlogPost.drop_collection()
@@ -375,6 +378,7 @@ class IndexesTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+        BlogPost.ensure_indexes()
         info = BlogPost.objects._collection.index_information()
         # we don't use _cls in with list fields by default
         self.assertEqual(sorted(info.keys()), ['_id_', 'tags.tag_1'])
@@ -411,6 +415,8 @@ class IndexesTest(unittest.TestCase):
 
         Test.drop_collection()
 
+        Test.ensure_indexes()
+
         obj = Test(a=1)
         obj.save()
 
@@ -440,6 +446,7 @@ class IndexesTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+        BlogPost.ensure_indexes()
         indexes = BlogPost.objects._collection.index_information()
         self.assertEqual(indexes['categories_1__id_1']['key'],
                                  [('categories', 1), ('_id', 1)])
@@ -485,6 +492,7 @@ class IndexesTest(unittest.TestCase):
             slug = StringField(unique=True)
 
         BlogPost.drop_collection()
+        BlogPost.ensure_indexes()
 
         post1 = BlogPost(title='test1', slug='test')
         post1.save()
@@ -508,6 +516,7 @@ class IndexesTest(unittest.TestCase):
             slug = StringField(unique_with='date.year')
 
         BlogPost.drop_collection()
+        BlogPost.ensure_indexes()
 
         post1 = BlogPost(title='test1', date=Date(year=2009), slug='test')
         post1.save()
@@ -535,6 +544,7 @@ class IndexesTest(unittest.TestCase):
 
         BlogPost.drop_collection()
 
+        BlogPost.ensure_indexes()
         post1 = BlogPost(title='test1',
                          sub=SubDocument(year=2009, slug="test"))
         post1.save()
@@ -564,6 +574,7 @@ class IndexesTest(unittest.TestCase):
             sub = EmbeddedDocumentField(SubDocument)
 
         BlogPost.drop_collection()
+        BlogPost.ensure_indexes()
 
         post1 = BlogPost(title='test1',
                          sub=SubDocument(year=2009, slug="test"))
@@ -606,8 +617,7 @@ class IndexesTest(unittest.TestCase):
         if version_array[0] < 2 and version_array[1] < 2:
             raise SkipTest('MongoDB needs to be 2.2 or higher for this test')
 
-        # Indexes are lazy so use list() to perform query
-        list(Log.objects)
+        Log.ensure_indexes()
         info = Log.objects._collection.index_information()
         self.assertEqual(3600,
                          info['created_1']['expireAfterSeconds'])
@@ -624,6 +634,7 @@ class IndexesTest(unittest.TestCase):
             }
 
         Customer.drop_collection()
+        Customer.ensure_indexes()
         cust = Customer(cust_id=1)
         cust.save()
 
@@ -673,6 +684,7 @@ class IndexesTest(unittest.TestCase):
         except UnboundLocalError:
             self.fail('Unbound local error at index + pk definition')
 
+        BlogPost.ensure_indexes()
         info = BlogPost.objects._collection.index_information()
         info = [value['key'] for key, value in info.iteritems()]
         index_item = [('_id', 1), ('comments.comment_id', 1)]

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -709,18 +709,20 @@ class QuerySetTest(unittest.TestCase):
         self.assertRaises(OperationError, throw_operation_error_not_a_document)
 
         Blog.drop_collection()
-
+        Blog.ensure_indexes()
         blog1 = Blog(title="code", posts=[post1, post2])
         blog1 = Blog.objects.insert(blog1)
         self.assertEqual(blog1.title, "code")
         self.assertEqual(Blog.objects.count(), 1)
 
         Blog.drop_collection()
+        Blog.ensure_indexes()
         blog1 = Blog(title="code", posts=[post1, post2])
         obj_id = Blog.objects.insert(blog1, load_bulk=False)
         self.assertEqual(obj_id.__class__.__name__, 'ObjectId')
 
         Blog.drop_collection()
+        Blog.ensure_indexes()
         post3 = Post(comments=[comment1, comment1])
         blog1 = Blog(title="foo", posts=[post1, post2])
         blog2 = Blog(title="bar", posts=[post2, post3])


### PR DESCRIPTION
Also makes sure you always create indexes in the background and removes a deprecated `dropDups` option