### PR TITLE
Add max_length param to the ListField

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -577,6 +577,10 @@ class ListField(ComplexBaseField):
         super(ListField, self).validate(value)
 
     def prepare_query_value(self, op, value):
+        # validate that $set doesn't contain more items than max_length
+        if op == 'set' and self.max_length is not None and len(value) > self.max_length:
+            self.error('ListField max length is exceeded')
+
         if self.field:
             if op in ('set', 'unset') and (not isinstance(value, basestring)
                and not isinstance(value, BaseDocument)

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -529,7 +529,7 @@ class ListField(ComplexBaseField):
 
     You can also limit the maximum number of items in the list with
     `max_length`. However, keep in mind that the validation can be bypassed by
-    using push__list_field_name or set__list_field_name.
+    using push__list_field_name.
 
     If using with ReferenceFields see: :ref:`one-to-many-with-listfields`
 
@@ -585,9 +585,11 @@ class ListField(ComplexBaseField):
             self.error('ListField max length is exceeded')
 
         if self.field:
-            if op in ('set', 'unset') and (not isinstance(value, basestring)
-               and not isinstance(value, BaseDocument)
-               and hasattr(value, '__iter__')):
+            if op in ('set', 'unset') and (
+                not isinstance(value, basestring) and
+                not isinstance(value, BaseDocument) and
+                hasattr(value, '__iter__')
+            ):
                 return [self.field.prepare_query_value(op, v) for v in value]
             return self.field.prepare_query_value(op, value)
         else:

--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -570,7 +570,10 @@ class ListField(ComplexBaseField):
            isinstance(value, basestring)):
             self.error('Only lists and tuples may be used in a list field')
 
-        # Validate that max_length is not exceeded. Note that it's not k
+        # Validate that max_length is not exceeded. Note that it's still
+        # possible to bypass this enforcement by using $push. However, if the
+        # document is reloaded after $push and then re-saved, the validation
+        # error will be raised.
         if self.max_length is not None and len(value) > self.max_length:
             self.error('ListField max length is exceeded')
 

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -876,6 +876,23 @@ class FieldTest(unittest.TestCase):
 
         Simple.drop_collection()
 
+    def test_list_field_max_length(self):
+        """Ensure that ListField's max_length is respected."""
+
+        class Foo(Document):
+            items = ListField(IntField(), max_length=5)
+
+        foo = Foo()
+
+        # make sure foo.save doesn't let us save too many items
+        for i in range(5):
+            foo.items.append(i)
+            foo.save()
+
+        foo.items.append(i+1)
+        self.assertRaises(ValidationError, foo.save)
+
+
     @unittest.skip("different behavior")
     def test_list_field_rejects_strings(self):
         """Strings aren't valid list field data types"""

--- a/tests/fields/fields.py
+++ b/tests/fields/fields.py
@@ -892,6 +892,9 @@ class FieldTest(unittest.TestCase):
         foo.items.append(i+1)
         self.assertRaises(ValidationError, foo.save)
 
+        # make sure foo.update with $set doesn't let us save too many items
+        self.assertRaises(ValidationError, foo.update, set__items=[1,2,3,4,5,6])
+
 
     @unittest.skip("different behavior")
     def test_list_field_rejects_strings(self):


### PR DESCRIPTION
This PR lets us add a `max_length` parameter to the ListField. Unfortunately, there are still ways to bypass this validation, e.g. by calling `obj.update(push__items='new item')`, but if we then reload the object and try `obj.save()`, we'll get a validation error.

@philfreo @thomasst lmk whatcha think.