### PR TITLE
Backport "modify()" method from latest mongoengine

### DIFF
--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -8,6 +8,7 @@ from mongoengine.base import (DocumentMetaclass, TopLevelDocumentMetaclass,
                               BaseDocument, get_document, ALLOW_INHERITANCE,
                               AUTO_CREATE_INDEX)
 from mongoengine.base.datastructures import WeakInstanceMixin
+from mongoengine.errors import (InvalidQueryError, InvalidDocumentError)
 from mongoengine.queryset import OperationError, NotUniqueError, QuerySet, DoesNotExist
 from mongoengine.connection import get_db, DEFAULT_CONNECTION_NAME
 from mongoengine.context_managers import switch_db, switch_collection
@@ -171,6 +172,43 @@ class Document(BaseDocument):
             if cls._meta.get('auto_create_index', AUTO_CREATE_INDEX):
                 cls.ensure_indexes()
         return cls._collection
+
+    def modify(self, query={}, **update):
+        """Perform an atomic update of the document in the database and reload
+        the document object using updated version.
+
+        Returns True if the document has been updated or False if the document
+        in the database doesn't match the query.
+
+        .. note:: All unsaved changes that have been made to the document are
+            rejected if the method returns True.
+
+        :param query: the update will be performed only if the document in the
+            database matches the query
+        :param update: Django-style update keyword arguments
+        """
+
+        if self.pk is None:
+            raise InvalidDocumentError("The document does not have a primary key.")
+
+        id_field = self._meta["id_field"]
+        query = query.copy() if isinstance(query, dict) else query.to_query(self)
+
+        if id_field not in query:
+            query[id_field] = self.pk
+        elif query[id_field] != self.pk:
+            raise InvalidQueryError("Invalid document modify query: it must modify only this document.")
+
+        updated = self._qs(**query).modify(new=True, **update)
+        if updated is None:
+            return False
+
+        _set(self, '_db_data', updated._db_data)
+        _set(self, '_internal_data', {})
+        _set(self, '_lazy', False)
+        self._clear_changed_fields()
+
+        return True
 
     def save(self, validate=True, clean=True,
              write_concern=None,  cascade=None, cascade_kwargs=None,

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo>=2.5'],
+      install_requires=['pymongo>=2.5,<3'],
       test_suite='nose.collector',
       **extra_opts
 )


### PR DESCRIPTION
This PR backports the `modify()` method from latest mongoengine.

@closeio/engineering / @wojcikstefan please review.