### PR TITLE
Auto comment - WIP

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -96,6 +96,8 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 msg = 'You have not defined a default connection'
             raise ConnectionError(msg)
         conn_settings = _connection_settings[alias].copy()
+        conn_settings.pop('query_trace', None)
+        conn_settings.pop('trace_depth', None)
 
         if hasattr(pymongo, 'version_tuple'):  # Support for 2.1+
             conn_settings.pop('name', None)

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -903,6 +903,14 @@ class QuerySet(object):
         queryset._initial_query = {}
         return queryset
 
+    def comment(self, text):
+        """Add a comment to the query.
+
+        See https://docs.mongodb.com/manual/reference/method/cursor.comment/#cursor.comment
+        for details.
+        """
+        return self._chainable_method("comment", text)
+
     def explain(self, format=False):
         """Return an explain plan record for the
         :class:`~mongoengine.queryset.QuerySet`\ 's cursor.
@@ -1637,6 +1645,25 @@ class QuerySet(object):
                       code)
         return code
 
+    def _chainable_method(self, method_name, val):
+        """Call a particular method on the PyMongo cursor call a particular chainable method
+        with the provided value.
+        """
+        queryset = self.clone()
+
+        # Get an existing cursor object or create a new one
+        cursor = queryset._cursor
+
+        # Find the requested method on the cursor and call it with the
+        # provided value
+        getattr(cursor, method_name)(val)
+
+        # Cache the value on the queryset._{method_name}
+        setattr(queryset, '_' + method_name, val)
+
+        return queryset
+
+        
     # Deprecated
     def ensure_index(self, **kwargs):
         """Deprecated use :func:`Document.ensure_index`"""

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 import copy
-import io
 import itertools
 import operator
 import os
@@ -88,7 +87,6 @@ def find_callers():
             f = f.f_back
             continue
         trace_comment.append('{}({})'.format(co.co_filename, f.f_lineno))
-        # rv.append([co.co_filename, f.f_lineno, co.co_name])
         f = f.f_back
         frame += 1
     return trace_comment

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -1760,6 +1760,21 @@ class QuerySetTest(unittest.TestCase):
         names = [a.author.name for a in Author.objects.order_by('-author__age')]
         self.assertEqual(names, ['User A', 'User B', 'User C'])
 
+    def test_comment(self):
+        """Make sure adding a comment to the query works."""
+        class User(Document):
+            age = IntField()
+
+        with db_ops_tracker() as q:
+            adult = (User.objects.filter(age__gte=18)
+                .comment('looking for an adult')
+                .first())
+            ops = q.get_ops()
+            self.assertEqual(len(ops), 1)
+            op = ops[0]
+            self.assertEqual(op['query']['$query'], {'age': {'$gte': 18}})
+            self.assertEqual(op['query']['$comment'], 'looking for an adult')
+
     def test_map_reduce(self):
         """Ensure map/reduce is both mapping and reducing.
         """


### PR DESCRIPTION
Enable auto commenting by passing `query_trace=True` and optionally `trace_depth=N` (defaults to 3)  to mongoengine.connect()
Enable the mongo system profiler by connecting to your local mongo and set `db.setProfilingLevel(2)` on your database.
```
$ mongo
MongoDB shell version v3.6.5
connecting to: mongodb://127.0.0.1:27017
> use test
switched to db test
> db.setProfilingLevel(2)
{ "was" : 0, "slowms" : 100, "ok" : 1 }
>
```

This covers most read ops. Inserts, updates, upserts, findAndModify, etc wont get comments.
Example system.profile doc with comments:
```
$ mongo
MongoDB shell version v3.6.5
connecting to: mongodb://127.0.0.1:27017
> use test
switched to db test
> db.system.profile.find({"ns": { $ne: "test.system.profile"}}).sort({$natural: -1}).limit(1).pretty()
{
	"op" : "query",
	"ns" : "test.foo",
	"query" : {
		"find" : "foo",
		"filter" : {
			"first_name" : "James"
		},
		"ntoreturn" : -1,
		"comment" : [
			"<ipython-input-4-460f39f6836a>(1)",
			"/Users/jsatterfield/venv/test/lib/python2.7/site-packages/IPython/core/interactiveshell.py(2869)",
			"/Users/jsatterfield/venv/test/lib/python2.7/site-packages/IPython/core/interactiveshell.py(2815)"
		]
	},
```
