### PR TITLE
Replace QuerySet.sum and QuerySet.average implementation

### DIFF
--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -2154,24 +2154,9 @@ class QuerySetTest(unittest.TestCase):
         avg = float(sum(ages)) / (len(ages))
         self.assertAlmostEqual(int(self.Person.objects.average('age')), avg)
 
-    def test_aggregate_average(self):
-        ages = [0, 23, 54, 12, 94, 27]
-        for i, age in enumerate(ages):
-            self.Person(name='test%s' % i, age=age).save()
-        self.Person(name='ageless person').save()
-
-        avg = float(sum(ages)) / (len(ages))
-        self.assertAlmostEqual(
-            int(self.Person.objects.aggregate_average('age')), avg
-        )
-
     def test_average_over_zero(self):
         self.Person(name='person', age=0).save()
         self.assertEqual(int(self.Person.objects.average('age')), 0)
-
-    def test_aggregate_average_over_zero(self):
-        self.Person(name='person', age=0).save()
-        self.assertEqual(int(self.Person.objects.aggregate_average('age')), 0)
 
     def test_sum(self):
         """Ensure that field can be summed over correctly."""
@@ -2182,17 +2167,7 @@ class QuerySetTest(unittest.TestCase):
 
         self.assertEqual(int(self.Person.objects.sum('age')), sum(ages))
 
-    def test_aggregate_sum(self):
-        ages = [0, 23, 54, 12, 94, 27]
-        for i, age in enumerate(ages):
-            self.Person(name='test%s' % i, age=age).save()
-        self.Person(name='ageless person').save()
-
-        self.assertEqual(
-            int(self.Person.objects.aggregate_sum('age')), sum(ages)
-        )
-
-    def test_aggregate_average_over_db_field(self):
+    def test_average_over_db_field(self):
         class UserVisit(Document):
             num_visits = IntField(db_field='visits')
 
@@ -2201,11 +2176,9 @@ class QuerySetTest(unittest.TestCase):
         UserVisit.objects.create(num_visits=20)
         UserVisit.objects.create(num_visits=10)
 
-        self.assertEqual(
-            UserVisit.objects.aggregate_average('num_visits'), 15
-        )
+        self.assertEqual(UserVisit.objects.average('num_visits'), 15)
 
-    def test_aggregate_sum_over_db_field(self):
+    def test_sum_over_db_field(self):
         class UserVisit(Document):
             num_visits = IntField(db_field='visits')
 
@@ -2214,7 +2187,7 @@ class QuerySetTest(unittest.TestCase):
         UserVisit.objects.create(num_visits=10)
         UserVisit.objects.create(num_visits=5)
 
-        self.assertEqual(UserVisit.objects.aggregate_sum('num_visits'), 15)
+        self.assertEqual(UserVisit.objects.sum('num_visits'), 15)
 
     def test_distinct(self):
         """Ensure that the QuerySet.distinct method works.


### PR DESCRIPTION
This commit drops the old (and poor) map-reduce/JS-based implementation of `QuerySet.sum` and `QuerySet.average` and replaces them with the aggregation-based implementation that previously lived on `QuerySet.aggregate_sum` and `QuerySet.aggregate_average`.

This is consistent upstream MongoEngine. It'll allow us to change our app's code immediately and then simply plug upstream ME instead of our fork.

Refs https://github.com/closeio/dashes/issues/379.