### PR TITLE
Rename clear_initial_query to clear_cls_query

### DIFF
--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -920,7 +920,7 @@ class QuerySet(object):
         queryset._ordering = queryset._get_order_by(keys)
         return queryset
 
-    def clear_initial_query(self):
+    def clear_cls_query(self):
         """ Sometimes we don't want the default _cls filter to be included in
         the query. This is a method to clear it.
         """

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -3087,14 +3087,14 @@ class QuerySetTest(unittest.TestCase):
         Test.objects(test='foo').update_one(upsert=True, set__test='foo')
         self.assertTrue('_cls' in Test._collection.find_one())
 
-    def test_clear_initial_query(self):
+    def test_clear_cls_query(self):
         class Test(Document):
             meta = {'allow_inheritance': True}
             test = StringField()
 
         Test.drop_collection()
         Test.objects.create(test='foo')
-        tests = Test.objects.clear_initial_query().all()
+        tests = Test.objects.clear_cls_query().all()
         self.assertEqual(tests.count(), 1)
         self.assertEqual(tests._initial_query, {})
 


### PR DESCRIPTION
This way we're consistent with the upstream repo (see https://github.com/MongoEngine/mongoengine/pull/2112).