### PR TITLE
Meaningful reference errors

### DIFF
--- a/mongoengine/base/fields.py
+++ b/mongoengine/base/fields.py
@@ -10,6 +10,7 @@ from mongoengine.errors import ValidationError
 
 from mongoengine.base.common import ALLOW_INHERITANCE
 from mongoengine.base.datastructures import BaseDict, BaseList
+from mongoengine.base.proxy import DocumentProxy
 
 __all__ = ("BaseField", "ComplexBaseField", "ObjectIdField", "GeoJsonBaseField")
 
@@ -103,9 +104,12 @@ class BaseField(object):
                     value = self.default() if callable(self.default) else self.default
                 else:
                     value = self.to_python(db_value)
+                    if isinstance(value, DocumentProxy):
+                        value._set_parent_ref(instance, name)
 
                 if hasattr(self, 'value_for_instance'):
                     value = self.value_for_instance(value, instance)
+
                 data[name] = value
 
             return data[name]


### PR DESCRIPTION
It's been painful trying to figure out which references are broken.

This PR needs more testing, but what do you think?

```
In [7]: c.pk
Out[7]: 'acti_JYLfSSgIrpHESqDfNZJAzi5eiw9F3q5zqJS7xtFZG3y'

In [8]: c._db_data['transferred_to']
Out[8]: 'acti_nonexistent'

In [9]: c.transferred_to.number
---------------------------------------------------------------------------
DoesNotExist                              Traceback (most recent call last)
/home/closeio/closeio/closeio/exporter/documents/__init__.py in <module>()
----> 1 c.transferred_to.number

/home/closeio/venv/src/mongoengine/build/lib/mongoengine/base/proxy.py in __getattr__(self, name)
     63         if name == '__members__':
     64             return dir(self._get_current_object())
---> 65         return getattr(self._get_current_object(), name)
     66 
     67     def __setitem__(self, key, value):

/home/closeio/venv/src/mongoengine/build/lib/mongoengine/base/proxy.py in _get_current_object(self)
    209                     )
    210                 error += ') has been deleted.'
--> 211                 raise DoesNotExist(error)
    212             document = self.__document_type._from_son(son)
    213             object.__setattr__(self, '_DocumentProxy__document', document)

DoesNotExist: Document (activity acti_nonexistent, referenced by Call acti_JYLfSSgIrpHESqDfNZJAzi5eiw9F3q5zqJS7xtFZG3y in field transferred_to) has been deleted.
```