### PR TITLE
Drop Python 2 from the testing matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-2.7
       - test-3.5
       - test-3.6
 
@@ -20,12 +19,6 @@ defaults: &defaults
       command: python setup.py test
 
 jobs:
-
-  test-2.7:
-    <<: *defaults
-    docker:
-    - image: circleci/python:2.7
-    - image: mongo:3.2.19
 
   test-3.5:
     <<: *defaults


### PR DESCRIPTION
...since Python 2 has [reached its EOL](https://www.python.org/doc/sunset-python-2/) on 1/1/2020.