### PR TITLE
Fix listfield prepare query value

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -604,7 +604,7 @@ class ListField(ComplexBaseField):
             self.error('ListField max length is exceeded')
 
         if self.field:
-            if op in ('set', 'unset') and (
+            if op in ('set', 'unset', None) and (
                 not isinstance(value, basestring) and
                 not isinstance(value, BaseDocument) and
                 hasattr(value, '__iter__')


### PR DESCRIPTION
If you have this field:
```
    sort: List[SortField] = ListField(
        CleanCatSerializableField(field_schema=sort_field)
    )
```
and then did:
```
LeadExport.objects.filter(sort=[])
```
it was not calling `CleanCatSerializableField.prepare_query_value` on each item, but instead passing the whole array to it, which it could not handle.
Upstream has this fixed already: https://github.com/MongoEngine/mongoengine/blob/master/mongoengine/fields.py#L977