### PR TITLE
Fix our fork of MongoEngine for MongoDB v4.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-3.5
-      - test-3.6
       - test-3.7
       - test-3.8
 
@@ -21,18 +19,6 @@ defaults: &defaults
       command: python setup.py test
 
 jobs:
-
-  test-3.5:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.5
-    - image: mongo:3.2.19
-
-  test-3.6:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.6
-    - image: mongo:3.2.19
 
   test-3.7:
     <<: *defaults

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -1260,9 +1260,9 @@ class QuerySet(object):
 
     @property
     def _cursor_args(self):
-        cursor_args = {
-            'no_cursor_timeout': not self._timeout,
-        }
+        cursor_args = {}
+        if not self._timeout:
+            cursor_args['no_cursor_timeout'] = True
         if self._loaded_fields:
             cursor_args['projection'] = self._loaded_fields.as_dict()
         return cursor_args

--- a/tests/queryset/queryset.py
+++ b/tests/queryset/queryset.py
@@ -789,13 +789,13 @@ class QuerySetTest(unittest.TestCase):
         """Ensures the cursor args can be set as expected
         """
         p = self.Person.objects
-        self.assertEqual(p._cursor_args, {'no_cursor_timeout': False})
+        self.assertEqual(p._cursor_args, {})
+
+        p = p.timeout(True)
+        self.assertEqual(p._cursor_args, {})
 
         p = p.timeout(False)
         self.assertEqual(p._cursor_args, {'no_cursor_timeout': True})
-
-        p = p.timeout(True)
-        self.assertEqual(p._cursor_args, {'no_cursor_timeout': False})
 
     def test_repeated_iteration(self):
         """Ensure that QuerySet rewinds itself one iteration finishes.


### PR DESCRIPTION
This PR makes sure that we only set `no_cursor_timeout` if timeout has been explicitly disabled via `QuerySet.timeout(False)`. Previously, we were setting `no_cursor_timeout: False` on many operations, some of which started actively rejecting (vs ignoring) this option in MongoDB v4.2. This is a backport of https://github.com/MongoEngine/mongoengine/pull/2160. It fixes MongoEngine running against MongoDB v4.2.

Without this fix, e.g. `Document.modify` (which calls PyMongo's `find_one_and_update`) would fails with the following error:
```
mongoengine.errors.OperationError: Update failed (BSON field 'no_cursor_timeout' is an unknown field., full error: {'ok': 0.0, 'errmsg': "BSON field 'no_cursor_timeout' is an unknown field.", 'code': 51177, 'codeName': 'Location51177'})
```

I also stopped testing Python versions v3.5 and v3.6 in this PR since they are past their EOL already: https://endoflife.date/python