### PR TITLE
Test against python 3.9 and 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ defaults: &defaults
       command: pip install --user -r test-requirements.txt
   - run:
       name: Test
-      command: nosetests
+      command: pytest tests/
 
 jobs:
   test-3.8:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,9 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-3.7
       - test-3.8
+      - test-3.9
+      - test-3.10
 
 defaults: &defaults
   working_directory: ~/code
@@ -19,15 +20,18 @@ defaults: &defaults
       command: nosetests
 
 jobs:
-
-  test-3.7:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.7
-    - image: mongo:3.2.19
-
   test-3.8:
     <<: *defaults
     docker:
     - image: circleci/python:3.8
+    - image: mongo:3.2.19
+  test-3.9:
+    <<: *defaults
+    docker:
+    - image: circleci/python:3.9
+    - image: mongo:3.2.19
+  test-3.10:
+    <<: *defaults
+    docker:
+    - image: circleci/python:3.10
     - image: mongo:3.2.19

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 -r requirements.txt
+pytest
 nose
 coverage
 blinker


### PR DESCRIPTION
This change also updates the test runner to be `pytest`.

None of the test logic has to change, and `pytest` [has explicit support for `nose` idioms](https://docs.pytest.org/en/7.1.x/how-to/nose.html). We should at some point drop those nose idioms and use pytest directly, but until then this is an easy way to get tests running in 3.10+ (which moves some imports around in a way that's not compatible with the `nose` runner)