### PR TITLE
Reduce unnecessary queries for polymorphic documents

### DIFF
--- a/mongoengine/fields.py
+++ b/mongoengine/fields.py
@@ -815,12 +815,19 @@ class ReferenceField(BaseField):
         return self.document_type_obj
 
     def to_mongo(self, value):
-        if isinstance(value, DBRef):
+        # We need to avoid using `isinstance` here. When the value is a
+        # `DocumentProxy`, calling `isinstance` will cause the underlying
+        # document to be fetched from the database, because `DocumentProxy`
+        # fakes its class using a custom `__class__` which does the fetch.
+
+        type_ = type(value)
+
+        if issubclass(type_, DBRef):
             if self.dbref:
                 return value
             else:
                 return value.id
-        elif isinstance(value, (Document, DocumentProxy)):
+        elif issubclass(type_, (Document, DocumentProxy)):
             document_type = self.document_type
             # We need the id from the saved object to create the DBRef
             pk = value.pk


### PR DESCRIPTION
When filtering on a polymorphic reference field by ID (and not object), extra queries are made to pull the object from the ID.

Also, see the results of the test when the fix is reverted (don't mind the wrong line numbers):
<img width="600" alt="Screen Shot 2023-04-20 at 08 35 12" src="https://user-images.githubusercontent.com/113755748/233281208-069ba143-ee3b-486e-b194-3200ca5fd197.png">
