### PR TITLE
Drop old Python versions that we no longer use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-3.8
-      - test-3.9
       - test-3.10
 
 defaults: &defaults
@@ -20,16 +18,6 @@ defaults: &defaults
       command: pytest tests/
 
 jobs:
-  test-3.8:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.8
-    - image: mongo:3.2.19
-  test-3.9:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.9
-    - image: mongo:3.2.19
   test-3.10:
     <<: *defaults
     docker:


### PR DESCRIPTION
Python v3.8 is EOL. Python v3.9 is soon to be EOL.

https://devguide.python.org/versions/ shows this:
<img width="855" alt="Screenshot 2025-01-14 at 12 50 07 PM" src="https://github.com/user-attachments/assets/43027ae9-dc95-409a-b56c-ca134c717a4f" />
