### PR TITLE
Add Python v3.11 to the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,5 +27,5 @@ jobs:
   test-3.11:
     <<: *defaults
     docker:
-    - image: circleci/python:3.11
+    - image: cimg/python:3.11
     - image: mongo:3.2.19

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,6 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-3.8
-      - test-3.9
       - test-3.10
 
 defaults: &defaults
@@ -20,16 +18,6 @@ defaults: &defaults
       command: pytest tests/
 
 jobs:
-  test-3.8:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.8
-    - image: mongo:3.2.19
-  test-3.9:
-    <<: *defaults
-    docker:
-    - image: circleci/python:3.9
-    - image: mongo:3.2.19
   test-3.10:
     <<: *defaults
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ workflows:
   workflow:
     jobs:
       - test-3.10
+      - test-3.11
 
 defaults: &defaults
   working_directory: ~/code
@@ -22,4 +23,9 @@ jobs:
     <<: *defaults
     docker:
     - image: circleci/python:3.10
+    - image: mongo:3.2.19
+  test-3.11:
+    <<: *defaults
+    docker:
+    - image: circleci/python:3.11
     - image: mongo:3.2.19


### PR DESCRIPTION
Follow-up after https://github.com/closeio/mongoengine/pull/47.