### PR TITLE
Add MongoDB 6.0.19 to the test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
     jobs:
       - test-3.10
       - test-3.11
+      - test-3.11-mongo6
 
 defaults: &defaults
   working_directory: ~/code
@@ -29,3 +30,8 @@ jobs:
     docker:
     - image: cimg/python:3.11
     - image: mongo:5.0.23
+  test-3.11-mongo6:
+    <<: *defaults
+    docker:
+    - image: cimg/python:3.11
+    - image: mongo:6.0.19


### PR DESCRIPTION
Test against the latest MongoDB 6 image to ensure compatibility 