### PR TITLE
Use `list_collection_names` vs `collection_names`

### DIFF
--- a/docs/upgrade.rst
+++ b/docs/upgrade.rst
@@ -500,7 +500,7 @@ Alternatively, you can rename your collections eg ::
             if old_style_name == new_style_name:
                 continue  # Nothing to do
 
-            existing = db.collection_names()
+            existing = db.list_collection_names()
             if old_style_name in existing:
                 if new_style_name in existing:
                     failure = True

--- a/mongoengine/document.py
+++ b/mongoengine/document.py
@@ -147,7 +147,7 @@ class Document(BaseDocument, metaclass=TopLevelDocumentMetaclass):
                 max_size = cls._meta['max_size'] or 10000000  # 10MB default
                 max_documents = cls._meta['max_documents']
 
-                if collection_name in db.collection_names():
+                if collection_name in db.list_collection_names():
                     cls._collection = db[collection_name]
                     # The collection already exists, check if its capped
                     # options match the specified capped options

--- a/tests/document/test_class_methods.py
+++ b/tests/document/test_class_methods.py
@@ -28,7 +28,7 @@ class ClassMethodsTest(unittest.TestCase):
         self.Person = Person
 
     def tearDown(self):
-        for collection in self.db.collection_names():
+        for collection in self.db.list_collection_names():
             if 'system.' in collection:
                 continue
             self.db.drop_collection(collection)
@@ -67,10 +67,10 @@ class ClassMethodsTest(unittest.TestCase):
         """
         collection_name = 'person'
         self.Person(name='Test').save()
-        self.assertTrue(collection_name in self.db.collection_names())
+        self.assertTrue(collection_name in self.db.list_collection_names())
 
         self.Person.drop_collection()
-        self.assertFalse(collection_name in self.db.collection_names())
+        self.assertFalse(collection_name in self.db.list_collection_names())
 
     def test_register_delete_rule(self):
         """Ensure that register delete rule adds a delete rule to the document
@@ -219,7 +219,7 @@ class ClassMethodsTest(unittest.TestCase):
             meta = {'collection': collection_name}
 
         Person(name="Test User").save()
-        self.assertTrue(collection_name in self.db.collection_names())
+        self.assertTrue(collection_name in self.db.list_collection_names())
 
         user_obj = self.db[collection_name].find_one()
         self.assertEqual(user_obj['name'], "Test User")
@@ -228,7 +228,7 @@ class ClassMethodsTest(unittest.TestCase):
         self.assertEqual(user_obj.name, "Test User")
 
         Person.drop_collection()
-        self.assertFalse(collection_name in self.db.collection_names())
+        self.assertFalse(collection_name in self.db.list_collection_names())
 
     def test_collection_name_and_primary(self):
         """Ensure that a collection with a specified name may be used.

--- a/tests/document/test_delta.py
+++ b/tests/document/test_delta.py
@@ -26,7 +26,7 @@ class DeltaTest(unittest.TestCase):
         self.Person = Person
 
     def tearDown(self):
-        for collection in self.db.collection_names():
+        for collection in self.db.list_collection_names():
             if 'system.' in collection:
                 continue
             self.db.drop_collection(collection)

--- a/tests/document/test_indexes.py
+++ b/tests/document/test_indexes.py
@@ -33,7 +33,7 @@ class IndexesTest(unittest.TestCase):
         self.Person = Person
 
     def tearDown(self):
-        for collection in self.db.collection_names():
+        for collection in self.db.list_collection_names():
             if 'system.' in collection:
                 continue
             self.db.drop_collection(collection)

--- a/tests/document/test_inheritance.py
+++ b/tests/document/test_inheritance.py
@@ -23,7 +23,7 @@ class InheritanceTest(unittest.TestCase):
         self.db = get_db()
 
     def tearDown(self):
-        for collection in self.db.collection_names():
+        for collection in self.db.list_collection_names():
             if 'system.' in collection:
                 continue
             self.db.drop_collection(collection)

--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -44,7 +44,7 @@ class InstanceTest(unittest.TestCase):
         self.Person = Person
 
     def tearDown(self):
-        for collection in self.db.collection_names():
+        for collection in self.db.list_collection_names():
             if 'system.' in collection:
                 continue
             self.db.drop_collection(collection)


### PR DESCRIPTION
Addresses deprecation warnings in prep for PyMongo 4.x upgrade:

```
tests/document/test_class_methods.py::ClassMethodsTest::test_drop_collection
  /Users/james/closeio/mongoengine/tests/document/test_class_methods.py:73: DeprecationWarning: collection_names is deprecated. Use list_collection_names instead.
    self.assertFalse(collection_name in self.db.collection_names())
```

See the details on collection name removal in the migration guide:

https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#database-collection-names-is-removed