### PR TITLE
Use command-based `createUser` vs `Database.add_user`

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -42,9 +42,9 @@ class ConnectionTest(unittest.TestCase):
         c.admin.system.users.delete_many({})
         c.mongoenginetest.system.users.delete_many({})
 
-        c.admin.add_user("admin", "password")
+        c.admin.command("createUser", "admin", pwd="password", roles=["root"])
         c.admin.authenticate("admin", "password")
-        c.mongoenginetest.add_user("username", "password")
+        c.mongoenginetest.command("createUser", "username", pwd="password", roles=["read"])
 
         self.assertRaises(ConnectionError, connect, "testdb_uri_bad", host='mongodb://test:password@localhost')
 


### PR DESCRIPTION
Addresses deprecation warnings in prep for pymongo 4.x upgrade:

```
tests/test_connection.py::ConnectionTest::test_connect_uri
  /Users/james/closeio/mongoengine/tests/test_connection.py:45: DeprecationWarning: add_user is deprecated and will be removed in PyMongo 4.0. Use db.command with createUser or updateUser instead
    c.admin.add_user("admin", "password")

tests/test_connection.py::ConnectionTest::test_connect_uri
tests/test_connection.py::ConnectionTest::test_connect_uri
  /Users/james/.pyenv/versions/3.8.12/envs/mongoengine/lib/python3.8/site-packages/pymongo/database.py:1333: DeprecationWarning: Creating a user with the read_only option or without roles is deprecated in MongoDB >= 2.6
    warnings.warn("Creating a user with the read_only option "
```

Without passing the role explicitly we'll get the following error.

```
>       raise OperationFailure(errmsg, code, response, max_wire_version)
E       pymongo.errors.OperationFailure: BSON field 'createUser.roles' is missing but a required field, full error: {'ok': 0.0, 'errmsg': "BSON field 'createUser.roles' is missing but a required field", 'code': 40414, 'codeName': 'Location40414'}
```

See details on `Database.add_user` deprecation in the migration guide:

https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#database-add-user-is-removed