### PR TITLE
PyMongo >= 4.2

### DIFF
--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -220,7 +220,7 @@ class query_counter(object):
     def _get_count(self):
         """ Get the number of queries. """
         ignore_query = {"ns": {"$ne": "%s.system.indexes" % self.db.name}}
-        count = self.db.system.profile.find(ignore_query).count() - self.counter
+        count = self.db.system.profile.count_documents(filter=ignore_query) - self.counter
         self.counter += 1
         return count
 

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -423,9 +423,26 @@ class QuerySet(object):
 
         if with_limit_and_skip and self._len is not None:
             return self._len
-        count = self._cursor.count(with_limit_and_skip=with_limit_and_skip)
+
+        options = {}
+        if with_limit_and_skip:
+            if self._limit is not None:
+                options["limit"] = self._limit
+            if self._skip is not None:
+                options["skip"] = self._skip
+        if self._hint not in (-1, None):
+            options["hint"] = self._hint
+
+        if self._query or options:
+            count = self._cursor.collection.count_documents(
+                filter=self._query, **options
+            )
+        else:
+            count = self._cursor.collection.estimated_document_count()
+
         if with_limit_and_skip:
             self._len = count
+
         return count
 
     def delete(self, write_concern=None, _from_doc_delete=False):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymongo==3.12.3
+pymongo==4.2.0

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo>=3.7'],
+      install_requires=['pymongo>=4.2,<5.0'],
       test_suite='nose.collector',
       **extra_opts
 )

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo>=3.0,<3.14'],
+      install_requires=['pymongo>=3.7'],
       test_suite='nose.collector',
       **extra_opts
 )

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -196,7 +196,7 @@ class ContextManagersTest(unittest.TestCase):
             self.assertEqual(0, q)
 
             for i in range(1, 51):
-                db.test.find({}).count()
+                db.test.estimated_document_count()
 
             self.assertEqual(50, q)
 


### PR DESCRIPTION
Bumps PyMongo from `3.12.3` to `4.2` and addresses accompanying failures