### PR TITLE
Use command-based `profile` vs `Database.set_profiling_level`

### DIFF
--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -175,14 +175,14 @@ class query_counter(object):
 
     def __enter__(self):
         """ On every with block we need to drop the profile collection. """
-        self.db.set_profiling_level(0)
+        self.db.command({"profile": 0})
         self.db.system.profile.drop()
-        self.db.set_profiling_level(2)
+        self.db.command({"profile": 2})
         return self
 
     def __exit__(self, t, value, traceback):
         """ Reset the profiling level. """
-        self.db.set_profiling_level(0)
+        self.db.command({"profile": 0})
 
     def __eq__(self, value):
         """ == Compare querycounter. """


### PR DESCRIPTION
Addresses deprecation warnings in prep for PyMongo 4.x upgrade:

```
tests/test_dereference.py: 3 warnings
  /Users/james/closeio/mongoengine/mongoengine/context_managers.py:178: DeprecationWarning: set_profiling_level() is deprecated. See the documentation for more information
    self.db.set_profiling_level(0)
```

See details on `Database.set_profiling_level` deprecation in the PyMongo migration guide:

https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#database-profiling-level-is-removed