### PR TITLE
Use `Collection.count_documents` vs `Collection.count`

### DIFF
--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -220,7 +220,7 @@ class query_counter(object):
     def _get_count(self):
         """ Get the number of queries. """
         ignore_query = {"ns": {"$ne": "%s.system.indexes" % self.db.name}}
-        count = self.db.system.profile.find(ignore_query).count() - self.counter
+        count = self.db.system.profile.count_documents(filter=ignore_query) - self.counter
         self.counter += 1
         return count
 

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -7,7 +7,6 @@ import warnings
 
 import pymongo
 from bson import json_util
-from bson.code import Code
 from pymongo.collection import ReturnDocument
 from pymongo.common import validate_read_preference
 from pymongo.read_concern import ReadConcern
@@ -433,7 +432,7 @@ class QuerySet(object):
         if self._hint not in (-1, None):
             options["hint"] = self._hint
 
-        if not self._query:
+        if not self._query and "hint" not in options:
             count = self._cursor.collection.estimated_document_count() - options.get(
                 "skip", 0
             )

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -433,7 +433,15 @@ class QuerySet(object):
         if self._hint not in (-1, None):
             options["hint"] = self._hint
 
-        count = self._cursor.collection.count_documents(filter=self._query, **options)
+        if not self._query:
+            count = self._cursor.collection.estimated_document_count() - options.get(
+                "skip", 0
+            )
+            return min(count, options.get("limit", count))
+        else:
+            count = self._cursor.collection.count_documents(
+                filter=self._query, **options
+            )
 
         if with_limit_and_skip:
             self._len = count

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -437,7 +437,7 @@ class QuerySet(object):
             count = self._cursor.collection.estimated_document_count() - options.get(
                 "skip", 0
             )
-            return min(count, options.get("limit", count))
+            count = min(count, options.get("limit", count))
         else:
             count = self._cursor.collection.count_documents(
                 filter=self._query, **options

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -422,9 +422,22 @@ class QuerySet(object):
 
         if with_limit_and_skip and self._len is not None:
             return self._len
-        count = self._cursor.count(with_limit_and_skip=with_limit_and_skip)
+
+        options = {}
+
+        if with_limit_and_skip:
+            if self._limit is not None:
+                options["limit"] = self._limit
+            if self._skip is not None:
+                options["skip"] = self._skip
+        if self._hint not in (-1, None):
+            options["hint"] = self._hint
+
+        count = self._cursor.collection.count_documents(filter=self._query, **options)
+
         if with_limit_and_skip:
             self._len = count
+
         return count
 
     def delete(self, write_concern=None, _from_doc_delete=False):

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -196,7 +196,7 @@ class ContextManagersTest(unittest.TestCase):
             self.assertEqual(0, q)
 
             for i in range(1, 51):
-                db.test.find({}).count()
+                db.test.count_documents({})
 
             self.assertEqual(50, q)
 


### PR DESCRIPTION
Addresses deprecation warnings in prep for PyMongo 4.x upgrade:

```
tests/test_context_managers.py: 50 warnings
  /Users/james/closeio/mongoengine/tests/test_context_managers.py:199: DeprecationWarning: count is deprecated. Use Collection.count_documents instead.
    db.test.find({}).count()
```

See details on the removal of `Collection.count` in the PyMongo migration guide:

https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-count-and-cursor-count-is-removed