### PR TITLE
Remove `db.authenticate`

### DIFF
--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -118,8 +118,6 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
             conn_settings.pop('name', None)
             conn_settings.pop('slaves', None)
             conn_settings.pop('is_slave', None)
-            conn_settings.pop('username', None)
-            conn_settings.pop('password', None)
         else:
             # Get all the slave connections
             if 'slaves' in conn_settings:
@@ -155,10 +153,6 @@ def get_db(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
         conn = get_connection(alias)
         conn_settings = _connection_settings[alias]
         db = conn[conn_settings['name']]
-        # Authenticate if necessary
-        if conn_settings['username'] and conn_settings['password']:
-            db.authenticate(conn_settings['username'],
-                            conn_settings['password'])
         _dbs[alias] = db
     return _dbs[alias]
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -35,28 +35,6 @@ class ConnectionTest(unittest.TestCase):
         conn = get_connection('testdb')
         self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
 
-    def test_connect_uri(self):
-        """Ensure that the connect() method works properly with uri's
-        """
-        c = connect(db='mongoenginetest', alias='admin')
-        c.admin.system.users.delete_many({})
-        c.mongoenginetest.system.users.delete_many({})
-
-        c.admin.command("createUser", "admin", pwd="password", roles=["root"])
-        c.admin.authenticate("admin", "password")
-        c.mongoenginetest.command("createUser", "username", pwd="password", roles=["read"])
-
-        self.assertRaises(ConnectionError, connect, "testdb_uri_bad", host='mongodb://test:password@localhost')
-
-        connect("testdb_uri", host='mongodb://username:password@localhost/mongoenginetest')
-
-        conn = get_connection()
-        self.assertTrue(isinstance(conn, pymongo.mongo_client.MongoClient))
-
-        db = get_db()
-        self.assertTrue(isinstance(db, pymongo.database.Database))
-        self.assertEqual(db.name, 'mongoenginetest')
-
     def test_register_connection(self):
         """Ensure that connections with different aliases may be registered.
         """


### PR DESCRIPTION
Passes `username` and `password` on to `MongoClient` on connection to authenticate there, and removes the `db.authenticate` call, which is currently deprecated (and removed in `pymongo>=4.0`). 

Removes associated failing test as well as full URI support is unnecessary for our integration.

See https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#database-authenticate-and-database-logout-are-removed:
<img width="857" alt="Screenshot 2025-01-21 at 11 25 26 AM" src="https://github.com/user-attachments/assets/5d6e657f-9073-4262-a745-c82b8d6579d6" />
