### PR TITLE
Use `MongoClient` vs `MongoReplicaSetClient`

### DIFF
--- a/docs/guide/connecting.rst
+++ b/docs/guide/connecting.rst
@@ -32,8 +32,8 @@ name - just supply the uri as the :attr:`host` to
 ReplicaSets
 ===========
 
-MongoEngine supports :class:`~pymongo.mongo_replica_set_client.MongoReplicaSetClient`
-to use them please use a URI style connection and provide the `replicaSet` name in the
+MongoEngine supports replica sets through :class:`~pymongo.mongo_client.MongoClient`.
+To use them please use a URI style connection and provide the `replicaSet` name in the
 connection kwargs.
 
 Read preferences are supported through the connection or via individual

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,6 +1,5 @@
 import pymongo
-from pymongo import (MongoClient, MongoReplicaSetClient, ReadPreference,
-                     uri_parser)
+from pymongo import MongoClient, ReadPreference, uri_parser
 
 __all__ = [
     'DEFAULT_CONNECTION_NAME',
@@ -127,18 +126,16 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
                 conn_settings['slaves'] = slaves
                 conn_settings.pop('read_preference', None)
 
-        connection_class = MongoClient
         if 'replicaSet' in conn_settings:
             conn_settings['hosts_or_uri'] = conn_settings.pop('host', None)
-            # Discard port since it can't be used on MongoReplicaSetClient
+            # Discard port since it can't be used with replicaSet
             conn_settings.pop('port', None)
             # Discard replicaSet if not base string
             if not isinstance(conn_settings['replicaSet'], str):
                 conn_settings.pop('replicaSet', None)
-            connection_class = MongoReplicaSetClient
 
         try:
-            _connections[alias] = connection_class(**conn_settings)
+            _connections[alias] = MongoClient(**conn_settings)
         except Exception as e:
             raise ConnectionError("Cannot connect to database %s :\n%s" % (alias, e))
     return _connections[alias]


### PR DESCRIPTION
`MongoReplicaSetClient` was [removed in PyMongo 4.x](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#mongoreplicasetclient). `MongoClient` can be used directly instead.

<img width="807" alt="image" src="https://github.com/user-attachments/assets/b3b0f065-68cd-4cbd-bb43-3086336d12a5" />