### PR TITLE
uuidrepresentation defaults to PYTHON_LEGACY

### DIFF
--- a/mongoengine/base/document.py
+++ b/mongoengine/base/document.py
@@ -1,4 +1,5 @@
 import operator
+import warnings
 from functools import partial
 
 import pymongo
@@ -8,6 +9,7 @@ from bson.son import SON
 from mongoengine.common import _import_class
 from mongoengine.errors import (ValidationError, LookUpError)
 from mongoengine.python_support import PY3, txt_type
+from mongoengine.pymongo_support import LEGACY_JSON_OPTIONS
 
 from mongoengine.base.proxy import DocumentProxy
 from mongoengine.base.common import get_document, ALLOW_INHERITANCE
@@ -193,9 +195,20 @@ class BaseDocument(object):
             message = "ValidationError (%s:%s) " % (self._class_name, pk)
             raise ValidationError(message, errors=errors)
 
-    def to_json(self):
+    def to_json(self, json_options=None):
         """Converts a document to JSON"""
-        return json_util.dumps(self.to_mongo())
+        if json_options is None:
+            warnings.warn(
+                "No 'json_options' are specified! Falling back to "
+                "LEGACY_JSON_OPTIONS with uuid_representation=PYTHON_LEGACY. "
+                "For use with other MongoDB drivers specify the UUID "
+                "representation to use. This will be changed to "
+                "uuid_representation=UNSPECIFIED in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            json_options = LEGACY_JSON_OPTIONS
+        return json_util.dumps(self.to_mongo(), json_options=json_options)
 
     @classmethod
     def from_json(cls, json_data):

--- a/mongoengine/connection.py
+++ b/mongoengine/connection.py
@@ -1,3 +1,4 @@
+import warnings
 import pymongo
 from pymongo import (MongoClient, MongoReplicaSetClient, ReadPreference,
                      uri_parser)
@@ -36,6 +37,7 @@ def register_connection(
     slaves=None,
     username=None,
     password=None,
+    uuidrepresentation=None,
     **kwargs
 ):
     """Add a connection.
@@ -84,7 +86,22 @@ def register_connection(
         })
         if "replicaSet" in host:
             conn_settings['replicaSet'] = True
+        if "uuidrepresentation" in uri_dict:
+            uuidrepresentation = uri_dict.get('uuidrepresentation')
 
+    if uuidrepresentation is None:
+        warnings.warn(
+            "No uuidrepresentation is specified! Falling back to "
+            "'pythonLegacy' which is the default for pymongo 3.x. "
+            "For compatibility with other MongoDB drivers this should be "
+            "specified as 'standard' or '{java,csharp}Legacy' to work with "
+            "older drivers in those languages. This will be changed to "
+            "'unspecified' in a future release.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        uuidrepresentation = "pythonLegacy"
+    conn_settings['uuidrepresentation'] = uuidrepresentation
     conn_settings.update(kwargs)
     _connection_settings[alias] = conn_settings
 

--- a/mongoengine/pymongo_support.py
+++ b/mongoengine/pymongo_support.py
@@ -1,0 +1,6 @@
+from bson import json_util, binary
+
+LEGACY_JSON_OPTIONS = json_util.LEGACY_JSON_OPTIONS.with_options(
+    uuid_representation=binary.UuidRepresentation.PYTHON_LEGACY,
+)
+

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -16,6 +16,7 @@ from mongoengine import signals
 from mongoengine.common import _import_class
 from mongoengine.context_managers import set_read_write_concern, set_write_concern
 from mongoengine.errors import InvalidQueryError, NotUniqueError, OperationError
+from mongoengine.pymongo_support import LEGACY_JSON_OPTIONS
 from mongoengine.queryset import transform
 from mongoengine.queryset.field_list import QueryFieldList
 from mongoengine.queryset.visitor import Q, QNode
@@ -1018,9 +1019,20 @@ class QuerySet(object):
 
     # JSON Helpers
 
-    def to_json(self):
+    def to_json(self, json_options=None):
         """Converts a queryset to JSON"""
-        return json_util.dumps(self.as_pymongo())
+        if json_options is None:
+            warnings.warn(
+                "No 'json_options' are specified! Falling back to "
+                "LEGACY_JSON_OPTIONS with uuid_representation=PYTHON_LEGACY. "
+                "For use with other MongoDB drivers specify the UUID "
+                "representation to use. This will be changed to "
+                "uuid_representation=UNSPECIFIED in a future release.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            json_options = LEGACY_JSON_OPTIONS
+        return json_util.dumps(self.as_pymongo(), json_options=json_options)
 
     def from_json(self, json_data):
         """Converts json data to unsaved objects"""


### PR DESCRIPTION
pymongo 3.x UUIDs are encoded to BSON Binary subtype 3 objects with PYTHON_LEGACY, and a warning is emitted when no uuidrepresentation is specified. New mongo applications are expected to use the STANDARD (subtype 4) encoding, which will be the new default in a future breaking change.

https://pymongo.readthedocs.io/en/stable/examples/uuid.html#standard