### PR TITLE
Use `update_one` instead of `update`

### DIFF
--- a/tests/document/test_instance.py
+++ b/tests/document/test_instance.py
@@ -1978,16 +1978,16 @@ class InstanceTest(unittest.TestCase):
         person = Person(name="name", age=10, job=job)
 
         from pymongo.collection import Collection
-        orig_update = Collection.update
+        orig_update_one = Collection.update_one
         try:
-            def fake_update(*args, **kwargs):
+            def fake_update_one(*args, **kwargs):
                 self.fail("Unexpected update for %s" % args[0].name)
-                return orig_update(*args, **kwargs)
+                return orig_update_one(*args, **kwargs)
 
-            Collection.update = fake_update
+            Collection.update = fake_update_one
             person.save()
         finally:
-            Collection.update = orig_update
+            Collection.update = orig_update_one
 
     def test_db_alias_tests(self):
         """ DB Alias tests """


### PR DESCRIPTION
`update` was [removed in PyMongo 4.x](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-update-is-removed), and `update_one` should be used instead. 

<img width="828" alt="image" src="https://github.com/user-attachments/assets/5ae2f817-b762-42e1-b40e-ccf455dac9c7" />
