### PR TITLE
Refactor `count` to `count_documents` and `estimated_document_count`

### DIFF
--- a/mongoengine/context_managers.py
+++ b/mongoengine/context_managers.py
@@ -220,7 +220,7 @@ class query_counter(object):
     def _get_count(self):
         """ Get the number of queries. """
         ignore_query = {"ns": {"$ne": "%s.system.indexes" % self.db.name}}
-        count = self.db.system.profile.find(ignore_query).count() - self.counter
+        count = self.db.system.profile.count_documents(filter=ignore_query) - self.counter
         self.counter += 1
         return count
 

--- a/mongoengine/queryset/queryset.py
+++ b/mongoengine/queryset/queryset.py
@@ -423,9 +423,26 @@ class QuerySet(object):
 
         if with_limit_and_skip and self._len is not None:
             return self._len
-        count = self._cursor.count(with_limit_and_skip=with_limit_and_skip)
+
+        options = {}
+        if with_limit_and_skip:
+            if self._limit is not None:
+                options["limit"] = self._limit
+            if self._skip is not None:
+                options["skip"] = self._skip
+        if self._hint not in (-1, None):
+            options["hint"] = self._hint
+
+        if self._query or options:
+            count = self._cursor.collection.count_documents(
+                filter=self._query, **options
+            )
+        else:
+            count = self._cursor.collection.estimated_document_count()
+
         if with_limit_and_skip:
             self._len = count
+
         return count
 
     def delete(self, write_concern=None, _from_doc_delete=False):

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(name='mongoengine',
       long_description=LONG_DESCRIPTION,
       platforms=['any'],
       classifiers=CLASSIFIERS,
-      install_requires=['pymongo>=3.0,<3.14'],
+      install_requires=['pymongo>=3.7'],
       test_suite='nose.collector',
       **extra_opts
 )

--- a/tests/test_context_managers.py
+++ b/tests/test_context_managers.py
@@ -196,7 +196,7 @@ class ContextManagersTest(unittest.TestCase):
             self.assertEqual(0, q)
 
             for i in range(1, 51):
-                db.test.find({}).count()
+                db.test.estimated_document_count()
 
             self.assertEqual(50, q)
 


### PR DESCRIPTION
PyMongo `~=4.0` removes `Cursor.count` and `Collection.count` and provides two new count methods: `Collection.count_documents` and `Collection.estimated_document_count`. [^1] 

![image](https://github.com/user-attachments/assets/8477eb9e-5677-4631-a1c8-af3b452732c3)

When possible, we now try using the estimated document count for count operations, but if a limit or skip is defined, or a hint is provided, we'll use the more accurate count. This mirrors the behavior of the upstream mongoengine implementation.

`Collection.count_documents` issues an aggregate query, which is accurate in all cases, but relatively expensive. `Collection.estimated_document_count` in PyMongo `>=4.0,<4.2` uses a $collStats aggregation to estimate the document count for the collection. In PyMongo `>4.2` it relies on the `count` MongoDB command.

[^1]: https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#collection-count-and-cursor-count-is-removed