### PR TITLE
Bump requirements.txt pymongo 3.12.3 -> 4.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pymongo==3.12.3
+pymongo==4.2.0


### PR DESCRIPTION
While we're currently backwards compatible with pymongo 3.7+ we're now focused primarily on 4.2.0+ compatibility.